### PR TITLE
[PLFM-9682] Generate complete classes for inline named objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.sagebionetworks</groupId>
 	<artifactId>schema-to-pojo</artifactId>
-	<version>0.6.12</version>
+	<version>0.6.13</version>
 	<packaging>pom</packaging>
 	<name>schema-to-pojo</name>
 	<description>Container for the rest of the sub-projects</description>

--- a/schema-to-pojo-core/pom.xml
+++ b/schema-to-pojo-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>schema-to-pojo</artifactId>
 		<groupId>org.sagebionetworks</groupId>
-		<version>0.6.12</version>
+		<version>0.6.13</version>
 	</parent>
 	<artifactId>schema-to-pojo-core</artifactId>
 	<name>schema-to-pojo-core</name>

--- a/schema-to-pojo-core/src/main/java/org/sagebionetworks/schema/generator/PojoGeneratorDriver.java
+++ b/schema-to-pojo-core/src/main/java/org/sagebionetworks/schema/generator/PojoGeneratorDriver.java
@@ -58,8 +58,14 @@ public class PojoGeneratorDriver {
 		// We are now ready to start creating the classes
 		// First create the package
 		JPackage _package = codeModel._package("");
+		// An inline named object (a property that declares its own name/id and properties rather
+		// than using a $ref to a root schema) is only ever turned into a class shell by
+		// createOrGetType during its parent's addProperties; the field + marshaling pass below
+		// runs once per schema, so without collecting these here they would compile to an empty
+		// class. Gather them up-front so each gets a complete POJO exactly once.
+		List<ObjectSchema> allToGenerate = collectAllSchemasToGenerate(list);
 		// Now recursively process all of the schema objects
-		for(ObjectSchema schema: list){
+		for(ObjectSchema schema: allToGenerate){
 			// Create each POJO
 			createPOJO(codeModel, schema, interfaceFactoryGenerator);
 		}
@@ -70,6 +76,63 @@ public class PojoGeneratorDriver {
 		interfaceFactoryGenerator.buildFactories();
 	}
 	
+	/**
+	 * Build the full list of schemas that need a complete POJO: every root schema, plus every
+	 * inline named OBJECT schema reachable from a root. An inline named object is a property whose
+	 * schema declares its own {@code name}/{@code id} and {@code properties} instead of using a
+	 * {@code $ref} to a root schema; {@link #createOrGetType} gives it a class shell, but the field
+	 * and marshaling handlers only run via {@link #createPOJO}, so it must be generated here too.
+	 *
+	 * <p>De-duplicates by id so a type referenced from several places is generated once. Recursive
+	 * reference instances (the copy a {@code $recursiveRef} resolves to, which carries the anchor's
+	 * id) are skipped &mdash; the anchor itself is already a root schema.</p>
+	 *
+	 * @param roots the root schemas, post-preprocessing
+	 * @return the roots followed by any inline named object schemas, each appearing once
+	 */
+	static List<ObjectSchema> collectAllSchemasToGenerate(List<ObjectSchema> roots) {
+		LinkedHashMap<String, ObjectSchema> byId = new LinkedHashMap<String, ObjectSchema>();
+		List<ObjectSchema> ordered = new ArrayList<ObjectSchema>();
+		for (ObjectSchema root : roots) {
+			ordered.add(root);
+			if (root.getId() != null) {
+				byId.put(root.getId(), root);
+			}
+		}
+		for (ObjectSchema root : roots) {
+			collectInlineNamedObjects(root, byId, ordered);
+		}
+		return ordered;
+	}
+
+	/**
+	 * Recursively collect inline named OBJECT schemas reachable from {@code schema}, adding each new
+	 * one (by id) to {@code byId} and {@code ordered}.
+	 */
+	private static void collectInlineNamedObjects(ObjectSchema schema,
+			LinkedHashMap<String, ObjectSchema> byId, List<ObjectSchema> ordered) {
+		Iterator<ObjectSchema> it = schema.getSubSchemaIterator();
+		while (it.hasNext()) {
+			ObjectSchema sub = it.next();
+			boolean isInlineNamedObject = sub.getId() != null
+					&& TYPE.OBJECT == sub.getType()
+					&& sub.getProperties() != null
+					&& sub.getEnum() == null
+					&& !sub.is$RecursiveRefInstance()
+					&& !byId.containsKey(sub.getId());
+			if (isInlineNamedObject) {
+				byId.put(sub.getId(), sub);
+				ordered.add(sub);
+			}
+			// Recurse regardless: a non-collected node (array wrapper, map, already-seen type) may
+			// still contain inline named objects deeper in the tree. A recursive-ref instance is the
+			// one place we must not descend — it is a copy of the anchor and would loop forever.
+			if (!sub.is$RecursiveRefInstance()) {
+				collectInlineNamedObjects(sub, byId, ordered);
+			}
+		}
+	}
+
 	static void validateDefaultConcreteTypes(JCodeModel codeModel, List<ObjectSchema> schemas) {
 		schemas.stream()
 			// Consider only interfaces with the the default concrete type

--- a/schema-to-pojo-gwt/pom.xml
+++ b/schema-to-pojo-gwt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>schema-to-pojo</artifactId>
 		<groupId>org.sagebionetworks</groupId>
-		<version>0.6.12</version>
+		<version>0.6.13</version>
 	</parent>
 	<artifactId>schema-to-pojo-gwt</artifactId>
 	<packaging>jar</packaging>

--- a/schema-to-pojo-integration-tests/pom.xml
+++ b/schema-to-pojo-integration-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>schema-to-pojo</artifactId>
 		<groupId>org.sagebionetworks</groupId>
-		<version>0.6.12</version>
+		<version>0.6.13</version>
 	</parent>
 	<artifactId>schema-to-pojo-integration-tests</artifactId>
 	<name>schema-to-pojo-integration-tests</name>

--- a/schema-to-pojo-integration-tests/src/test/java/org/sagebionetworks/schema/InlineNamedRecursiveTest.java
+++ b/schema-to-pojo-integration-tests/src/test/java/org/sagebionetworks/schema/InlineNamedRecursiveTest.java
@@ -1,0 +1,50 @@
+package org.sagebionetworks.schema;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.sagebionetworks.InlineNamedRecursive;
+import org.sagebionetworks.InlineNamedRecursiveCompound;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.EntityFactory;
+
+/**
+ * Verifies that an inline named OBJECT (a property declaring its own name/id and properties rather
+ * than using a $ref to a root schema) is generated as a complete, marshalable class, and that its
+ * $recursiveRef slots resolve to the anchor type &mdash; both the array-of-$recursiveRef form
+ * ({@code children}) and the direct-$recursiveRef form ({@code single}).
+ */
+public class InlineNamedRecursiveTest {
+
+	@Test
+	public void testInlineNamedObjectGeneratesCompleteClassAndRoundTrips()
+			throws JSONObjectAdapterException {
+		InlineNamedRecursive grandchild = new InlineNamedRecursive();
+		grandchild.setName("grandchild");
+
+		InlineNamedRecursiveCompound compound = new InlineNamedRecursiveCompound();
+		compound.setLabel("compound");
+		// Array-of-$recursiveRef slot resolves to List<InlineNamedRecursive>.
+		List<InlineNamedRecursive> children = new ArrayList<InlineNamedRecursive>();
+		children.add(grandchild);
+		compound.setChildren(children);
+		// Direct-$recursiveRef slot resolves to a single InlineNamedRecursive.
+		InlineNamedRecursive single = new InlineNamedRecursive();
+		single.setName("single");
+		compound.setSingle(single);
+
+		InlineNamedRecursive parent = new InlineNamedRecursive();
+		parent.setName("parent");
+		parent.setCompound(compound);
+
+		// call under test: a full JSON round trip through the generated marshaling.
+		String json = EntityFactory.createJSONStringForEntity(parent);
+		InlineNamedRecursive clone = EntityFactory.createEntityFromJSONString(json,
+				InlineNamedRecursive.class);
+
+		assertEquals(parent, clone);
+	}
+}

--- a/schema-to-pojo-integration-tests/src/test/resources/org/sagebionetworks/InlineNamedRecursive.json
+++ b/schema-to-pojo-integration-tests/src/test/resources/org/sagebionetworks/InlineNamedRecursive.json
@@ -1,0 +1,30 @@
+{
+	"type": "object",
+	"$recursiveAnchor": true,
+	"description": "A recursive root containing an inline named object whose properties recurse back to the root. Exercises that an inline named OBJECT (declaring its own name/id and properties, not a $ref) is generated as a complete class with fields and marshaling, and that both array-of-$recursiveRef and direct-$recursiveRef slots inside it resolve to the anchor type.",
+	"properties": {
+		"name": {
+			"type": "string"
+		},
+		"compound": {
+			"type": "object",
+			"name": "InlineNamedRecursiveCompound",
+			"id": "org.sagebionetworks.InlineNamedRecursiveCompound",
+			"description": "An inline named object nested inside the recursive root.",
+			"properties": {
+				"children": {
+					"type": "array",
+					"items": {
+						"$recursiveRef": "#"
+					}
+				},
+				"single": {
+					"$recursiveRef": "#"
+				},
+				"label": {
+					"type": "string"
+				}
+			}
+		}
+	}
+}

--- a/schema-to-pojo-lib/pom.xml
+++ b/schema-to-pojo-lib/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>schema-to-pojo</artifactId>
 		<groupId>org.sagebionetworks</groupId>
-		<version>0.6.12</version>
+		<version>0.6.13</version>
 	</parent>
 	<artifactId>schema-to-pojo-lib</artifactId>
 	<name>schema-to-pojo-lib</name>

--- a/schema-to-pojo-maven-plugin/pom.xml
+++ b/schema-to-pojo-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>schema-to-pojo</artifactId>
 		<groupId>org.sagebionetworks</groupId>
-		<version>0.6.12</version>
+		<version>0.6.13</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>schema-to-pojo-maven-plugin</artifactId>

--- a/schema-to-pojo-org-json/pom.xml
+++ b/schema-to-pojo-org-json/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>schema-to-pojo</artifactId>
 		<groupId>org.sagebionetworks</groupId>
-		<version>0.6.12</version>
+		<version>0.6.13</version>
 	</parent>
 	<artifactId>schema-to-pojo-org-json</artifactId>
 	<name>schema-to-pojo-org-json</name>


### PR DESCRIPTION
An inline named object property (one that declares its own name/id and properties rather than referencing a root schema via $ref) was only ever given a class shell by createOrGetType during its parent's addProperties; the field and JSON-marshaling pass runs once per schema in createAllClasses, which iterated only the root schema list. The result compiled to an empty class.

Collect inline named OBJECT schemas reachable from each root (deduped by id, skipping $recursiveRef instances) and generate a complete POJO for each. This makes inline named compounds with recursive ($recursiveRef) query slots generate as fully typed, marshalable classes.